### PR TITLE
OPENNLP-1698: Switch to extjwnl in jwnl-addon

### DIFF
--- a/jwnl-addon/pom.xml
+++ b/jwnl-addon/pom.xml
@@ -33,6 +33,11 @@
   <packaging>jar</packaging>
   <name>Apache OpenNLP JWNL Addon</name>
 
+  <properties>
+    <extjwnl.version>2.0.5</extjwnl.version>
+    <wn-data.version>1.2</wn-data.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.opennlp</groupId>
@@ -40,10 +45,17 @@
     </dependency>
 
     <dependency>
-      <groupId>net.sf.jwordnet</groupId>
-      <artifactId>jwnl</artifactId>
-      <version>1.3.3</version>
-      <scope>compile</scope>
+      <groupId>net.sf.extjwnl</groupId>
+      <artifactId>extjwnl</artifactId>
+      <version>${extjwnl.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>net.sf.extjwnl</groupId>
+      <artifactId>extjwnl-data-wn31</artifactId>
+      <version>${wn-data.version}</version>
+      <optional>true</optional>
+      <scope>runtime</scope>
     </dependency>
     
     <dependency>
@@ -59,6 +71,13 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/jwnl-addon/src/test/java/opennlp/jwnl/lemmatizer/JWNLLemmatizerTest.java
+++ b/jwnl-addon/src/test/java/opennlp/jwnl/lemmatizer/JWNLLemmatizerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opennlp.jwnl.lemmatizer;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import net.sf.extjwnl.JWNLException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JWNLLemmatizerTest {
+
+  // SUT
+  private JWNLLemmatizer lemmatizer;
+
+  @BeforeEach
+  public void setUp() throws JWNLException {
+    lemmatizer = new JWNLLemmatizer();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideData")
+  public void testLemmatize(String word, String posTag, String expectedLemma) {
+    String lemma = lemmatizer.lemmatize(word, posTag);
+    assertNotNull(lemma);
+    assertEquals(expectedLemma, lemma);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideData")
+  public void testLemmatizeArray(String word, String posTag, String expectedLemma) {
+    String[] lemma = lemmatizer.lemmatize(new String[]{word}, new String[]{posTag});
+    assertNotNull(lemma);
+    assertEquals(1, lemma.length);
+    assertEquals(expectedLemma, lemma[0]);
+  }
+
+  @Test
+  public void testLemmatizeList() {
+    assertThrows(UnsupportedOperationException.class, () -> {
+      lemmatizer.lemmatize(List.of("mouse"), List.of("NN"));
+    });
+  }
+
+  private static Stream<Arguments> provideData() {
+    return Stream.of(
+        Arguments.of("the", "DT", "the"),
+        Arguments.of("cats", "NN", "cat"),
+        Arguments.of("saw", "VB", "see"),
+        Arguments.of("best", "JJS", "good"),
+        Arguments.of("upside", "RB", "upside")
+    );
+  }
+}

--- a/jwnl-addon/src/test/resources/log4j2.xml
+++ b/jwnl-addon/src/test/resources/log4j2.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+-->
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <!--
+                The pattern can be adjusted as needed, see https://logging.apache.org/log4j/2.x/manual/layouts.html
+            -->
+            <PatternLayout pattern="%m%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="opennlp.jwnl.lemmatizer" level="warn"/>
+        <Logger name="opennlp.tools" level="warn"/>
+        <Root level="INFO">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
                 <configuration>
                     <release>${java.version}</release>
                     <compilerArgument>-Xlint</compilerArgument>


### PR DESCRIPTION
Change
-

- migrates jwnl-addon to `net.sf.extjwnl` (2.0.5)
- simplifies constructor of `JWNLLemmatizer`
- adds new unit test: `JWNLLemmatizerTest` with line coverage > 90%

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn clean install` at the root opennlp-sandbox folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp-sandbox folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp-sandbox folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
